### PR TITLE
propsの指定方法をリファクタリング

### DIFF
--- a/src/components/Atoms/Avator/index.tsx
+++ b/src/components/Atoms/Avator/index.tsx
@@ -1,12 +1,23 @@
+import { FC } from 'react';
 import styles from './index.module.css';
 import Image from "next/image";
 
-type Props = {
+interface Props {
+  /**
+   * 画像のパス
+   */
   src: string;
+
+  /**
+   * 画像のalt
+   */
   alt?: string;
 }
 
-export const Avator = ({ src, alt }:Props) => {
+export const Avator: FC<Props> = ({ 
+  src,
+  alt
+}) => {
   return (
     <Image
       src={`/${src}`}

--- a/src/components/Atoms/IntroTitle/index.stories.ts
+++ b/src/components/Atoms/IntroTitle/index.stories.ts
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof IntroTitle>;
 
 export const Default: Story = {
   args: {
-    level: 1,
+    as: "h1",
     children: "IntroTitleが\n入ります"
   }
 };

--- a/src/components/Atoms/IntroTitle/index.tsx
+++ b/src/components/Atoms/IntroTitle/index.tsx
@@ -3,9 +3,9 @@ import styles from './index.module.css';
 
 interface Props {
   /**
-   * 見出しのレベル
+   * タグの指定
    */
-  level?: 1 | 2 | 3 | 4 | 5 | 6;
+  as?: keyof JSX.IntrinsicElements;
 
   /**
    * 見出しの中身
@@ -14,10 +14,9 @@ interface Props {
 }
 
 export const IntroTitle: FC<Props> = ({
-  level = 1,
+  as: Tag = 'h1',
   children
 }) => {
-  const Tag = `h${level}` as keyof JSX.IntrinsicElements;
   return (
     <Tag className={styles.title}>{children}</Tag>
   );

--- a/src/components/Atoms/IntroTitle/index.tsx
+++ b/src/components/Atoms/IntroTitle/index.tsx
@@ -1,11 +1,22 @@
+import { FC, ReactNode } from 'react';
 import styles from './index.module.css';
 
-type Props = {
+interface Props {
+  /**
+   * 見出しのレベル
+   */
   level?: 1 | 2 | 3 | 4 | 5 | 6;
-  children: React.ReactNode;
+
+  /**
+   * 見出しの中身
+   */
+  children: ReactNode;
 }
 
-export const IntroTitle = ({ level = 1, children }: Props) => {
+export const IntroTitle: FC<Props> = ({
+  level = 1,
+  children
+}) => {
   const Tag = `h${level}` as keyof JSX.IntrinsicElements;
   return (
     <Tag className={styles.title}>{children}</Tag>

--- a/src/components/Atoms/ListItem/index.tsx
+++ b/src/components/Atoms/ListItem/index.tsx
@@ -1,11 +1,22 @@
+import { FC } from 'react';
 import styles from './index.module.css';
 
-type Props = {
+interface Props {
+  /**
+   * タイトル
+   */
   title: string;
+
+  /**
+   * 詳細
+   */
   detail: string;
 }
 
-export const ListItem = ({ title, detail }:Props) => {
+export const ListItem: FC<Props> = ({
+  title,
+  detail
+}) => {
   return  (
     <div className={styles.listItem}>
       <div className={styles.title}>{title}</div>

--- a/src/components/Atoms/Logo/index.tsx
+++ b/src/components/Atoms/Logo/index.tsx
@@ -1,12 +1,23 @@
+import { FC } from 'react';
 import styles from './index.module.css';
 import Link from 'next/link';
 
-type LinkProps = {
+interface Props {
+  /**
+   * リンクを有効にするかどうか
+   */
   link?: boolean;
+
+  /**
+   * リンク先
+   */
   href?: string;
 }
 
-export const Logo = ({ link, href="/" }: LinkProps) => {
+export const Logo: FC<Props> = ({
+  link,
+  href="/"
+}) => {
   return link ? (
     <Link href={href} className={styles.logo}>
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 167 33">

--- a/src/components/Atoms/MaterialIcon/index.tsx
+++ b/src/components/Atoms/MaterialIcon/index.tsx
@@ -1,16 +1,28 @@
+import { FC, ReactNode } from 'react';
 import styles from './index.module.css';
 
-type Props = {
+interface Props {
+  /**
+   * マテリアルアイコンのサイズ
+   */
   fontSize?: number;
+
+  /**
+   * マテリアルアイコンの色
+   */
   color?: string;
-  children: React.ReactNode;
+
+  /**
+   * マテリアルアイコンの中身
+   */
+  children: ReactNode;
 }
 
-export const MaterialIcon = ({ 
+export const MaterialIcon: FC<Props> = ({ 
   fontSize = 1.8,
   color = "var(--color-primary)",
   children
-}:Props) => {
+}) => {
   return (
     <i
       className={`${styles.icon} material-icons`}

--- a/src/components/Atoms/MessageImage/index.tsx
+++ b/src/components/Atoms/MessageImage/index.tsx
@@ -1,12 +1,23 @@
+import { FC } from 'react';
 import styles from './index.module.css';
 import Image from "next/image";
 
-type Props = {
+interface Props {
+  /**
+   * 画像のパス
+   */
   src: string;
+
+  /**
+   * 画像のalt
+   */
   alt?: string;
 }
 
-export const MessageImage = ({ src, alt }:Props) => {
+export const MessageImage: FC<Props> = ({
+  src,
+  alt
+}) => {
   return (
     <div className={styles.messageImage}>
       <Image

--- a/src/components/Atoms/NewsItem/index.tsx
+++ b/src/components/Atoms/NewsItem/index.tsx
@@ -1,13 +1,28 @@
+import { FC } from 'react';
 import styles from './index.module.css';
-// import Link from 'next/link';
 
-type Props = {
+interface Props {
+  /**
+   * リンク先
+   */
   href: string;
+
+  /**
+   * 日付
+   */
   date: string;
+
+  /**
+   * テキスト
+   */
   text: string;
 }
 
-export const NewsItem = ({ href, date, text }:Props) => {
+export const NewsItem: FC<Props> = ({
+  href,
+  date,
+  text
+}) => {
   return  (
     <a href={href} className={styles.newsItem}>
       <div className={styles.date}>{date}</div>

--- a/src/components/Atoms/PageTitle/index.tsx
+++ b/src/components/Atoms/PageTitle/index.tsx
@@ -1,10 +1,16 @@
+import { FC, ReactNode } from 'react';
 import styles from './index.module.css';
 
-type Props = {
-  children: React.ReactNode;
+interface Props {
+  /**
+   * タイトル
+   */
+  children: ReactNode;
 }
 
-export const PageTitle = ({ children }: Props) => {
+export const PageTitle: FC<Props> = ({
+  children
+}) => {
   return (
     <div className={styles.pageTitle}>
       <div className={styles.inner}>

--- a/src/components/Atoms/SectionTitle/index.stories.ts
+++ b/src/components/Atoms/SectionTitle/index.stories.ts
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof SectionTitle>;
 
 export const Default: Story = {
   args: {
-    level: 1,
+    as: "h1",
     children: "SectionTitle"
   }
 };

--- a/src/components/Atoms/SectionTitle/index.tsx
+++ b/src/components/Atoms/SectionTitle/index.tsx
@@ -3,9 +3,9 @@ import styles from './index.module.css';
 
 interface Props {
   /**
-   * 見出しのレベル
+   * タグの指定
    */
-  level?: 1 | 2 | 3 | 4 | 5 | 6;
+  as?: keyof JSX.IntrinsicElements;
 
   /**
    * 見出しの中身
@@ -14,10 +14,9 @@ interface Props {
 }
 
 export const SectionTitle: FC<Props> = ({
-  level = 1,
+  as: Tag = "h1",
   children
 }) => {
-  const Tag = `h${level}` as keyof JSX.IntrinsicElements;
   return (
     <Tag className={styles.title}>{children}</Tag>
   );

--- a/src/components/Atoms/SectionTitle/index.tsx
+++ b/src/components/Atoms/SectionTitle/index.tsx
@@ -1,11 +1,22 @@
+import { FC, ReactNode } from 'react';
 import styles from './index.module.css';
 
-type Props = {
+interface Props {
+  /**
+   * 見出しのレベル
+   */
   level?: 1 | 2 | 3 | 4 | 5 | 6;
-  children: React.ReactNode;
+
+  /**
+   * 見出しの中身
+   */
+  children: ReactNode;
 }
 
-export const SectionTitle = ({ level = 1, children }: Props) => {
+export const SectionTitle: FC<Props> = ({
+  level = 1,
+  children
+}) => {
   const Tag = `h${level}` as keyof JSX.IntrinsicElements;
   return (
     <Tag className={styles.title}>{children}</Tag>

--- a/src/components/Atoms/TextLink/index.tsx
+++ b/src/components/Atoms/TextLink/index.tsx
@@ -1,12 +1,23 @@
+import { FC, ReactNode } from 'react';
 import styles from './index.module.css';
 import Link from 'next/link';
 
-type Props = {
+interface Props {
+  /**
+   * リンク先
+   */
   href?: string;
-  children: React.ReactNode;
+
+  /**
+   * 子要素
+   */
+  children: ReactNode;
 }
 
-export const TextLink = ({ href="/", children }: Props) => {
+export const TextLink: FC<Props> = ({
+  href="/",
+  children
+}) => {
   return (
     <Link href={href} className={styles.link}>
       { children }

--- a/src/components/Molecules/List/index.tsx
+++ b/src/components/Molecules/List/index.tsx
@@ -1,16 +1,29 @@
+import { FC } from 'react';
 import styles from './index.module.css';
 import { ListItem } from '../../Atoms/ListItem';
 
 type ListItem = {
+  /**
+   * タイトル
+   */
   title: string,
+
+  /**
+   * 詳細
+   */
   detail: string,
 }
 
-type Props = {
+interface Props {
+  /**
+   * リストデータ
+   */
   data: ListItem[]
 }
 
-export const List = ({ data }:Props) => {
+export const List: FC<Props> = ({
+  data
+}) => {
   return  (
     <div className={styles.list}>
       {data.map((item, index) => (

--- a/src/components/Molecules/NewsList/index.tsx
+++ b/src/components/Molecules/NewsList/index.tsx
@@ -1,17 +1,34 @@
+import { FC } from 'react';
 import styles from './index.module.css';
 import { NewsItem } from '../../Atoms/NewsItem';
 
 type ListItem = {
+  /**
+   * リンク先
+   */
   href: string,
+
+  /**
+   * 日付
+   */
   date: string,
+
+  /**
+   * テキスト
+   */
   text: string,
 }
 
-type Props = {
+interface Props {
+  /**
+   * リストデータ
+   */
   data: ListItem[]
 }
 
-export const NewsList = ({ data }:Props) => {
+export const NewsList:FC<Props> = ({
+  data
+}) => {
   return  (
     <div className={styles.newsList}>
       {data.map((item, index) => (

--- a/src/components/Molecules/ServiceItem/index.tsx
+++ b/src/components/Molecules/ServiceItem/index.tsx
@@ -1,14 +1,35 @@
-import styles from './index.module.css';
+
+import { FC } from 'react';import styles from './index.module.css';
 import { MaterialIcon } from "@/components/Atoms/MaterialIcon"
 
-type Props = {
+interface Props {
+  /**
+   * リンク先
+   */
   href: string;
+
+  /**
+   * アイコン
+   */
   icon: string;
+
+  /**
+   * タイトル
+   */
   title: string;
+
+  /**
+   * 説明
+   */
   description: string;
 }
 
-export const ServiceItem = ({ href, icon, title, description }:Props) => {
+export const ServiceItem: FC<Props> = ({
+  href,
+  icon,
+  title,
+  description
+}) => {
   return  (
     <a href={href} className={styles.serviceItem}>
       <div className={styles.header}>


### PR DESCRIPTION
- typeからinterfaceに変更
- タグの指定をlevelからasに変更

---

propsの型を指定する方法には、"type"と"interface"の2つがあります。これらは、コンポーネントがどのようなデータを受け取るかを定義するためのものです。

**type**
TypeScriptの基本的な機能であり、特定のデータ型や型エイリアスを定義するために使用されます。typeは既存の型を拡張したり、新しい型を作成したりするのに適しています。

**interface**
TypeScriptの専用の機能であり、主にオブジェクトの形状やクラスのメンバーを定義するために使用されます。interfaceは既存の型を拡張することもできますが、主な目的はオブジェクトの形状を明示することです。