### PR TITLE
ニュース詳細、一覧・前・次の記事ボタンを設置

### DIFF
--- a/src/app/news/details/[postId]/page.tsx
+++ b/src/app/news/details/[postId]/page.tsx
@@ -9,7 +9,9 @@ export async function generateStaticParams() {
 
   const paths = contents.map((post:any) => {
     return {
-      postId: post.id,
+      params: {
+        postId: post.id.toString(),
+      },
     };
   });
 
@@ -21,6 +23,12 @@ export default async function StaticDetailPage({
   } : {
     params: { postId: string };
   }) {
+  // 前・次の記事のIDを取得
+  const { contents } = await getList();
+  const index = contents.findIndex((content) => content.id === postId);
+  const prevId = contents[index - 1] ? contents[index - 1].id : null;
+  const nextId = contents[index + 1] ? contents[index + 1].id : null;
+
   const post = await getDetail(postId);
 
   if(!post) {
@@ -34,7 +42,13 @@ export default async function StaticDetailPage({
 
   return (
     <div>
-      <NewsDetail title={formattedPost.title} data={formattedPost.publishDate} eyecatch={formattedPost.eyecatch}>
+      <NewsDetail
+        title={formattedPost.title}
+        data={formattedPost.publishDate}
+        eyecatch={formattedPost.eyecatch}
+        prevId={prevId}
+        nextId={nextId}
+      >
         {parse(formattedPost.content)}
       </NewsDetail>
     </div>

--- a/src/components/Atoms/CustomButton/index.module.css
+++ b/src/components/Atoms/CustomButton/index.module.css
@@ -1,5 +1,5 @@
 .button {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 16px 24px;

--- a/src/components/Atoms/CustomButton/index.module.css
+++ b/src/components/Atoms/CustomButton/index.module.css
@@ -1,0 +1,41 @@
+.button {
+  padding: 16px 24px;
+  border-radius: 4px;
+  background-color: var(--color-primary);
+  border: 1px solid var(--color-primary);
+  color: var(--color-white);
+  box-sizing: border-box;
+  text-align: center;
+  text-decoration: none;
+  transition: var(--transition-base);
+}
+
+.button:hover {
+  opacity: 0.7;
+}
+
+.button:focus {
+  box-shadow: var(--shadow-focus);
+}
+
+.outline {
+  background-color: var(--color-white);
+  border: 1px solid var(--color-primary);
+  color: var(--color-primary);
+}
+
+.ghost {
+  background-color: var(--color-white);
+  border: 1px solid var(--color-transparent);
+  color: var(--color-primary);
+}
+
+.small {
+  padding: 8px 16px;
+  font-size: 1.4rem;
+}
+
+.large {
+  padding: 24px 32px;
+  font-size: 1.8rem;
+}

--- a/src/components/Atoms/CustomButton/index.module.css
+++ b/src/components/Atoms/CustomButton/index.module.css
@@ -1,4 +1,7 @@
 .button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 16px 24px;
   border-radius: 4px;
   background-color: var(--color-primary);

--- a/src/components/Atoms/CustomButton/index.stories.tsx
+++ b/src/components/Atoms/CustomButton/index.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { CustomButton } from './index';
+
+const meta: Meta<typeof CustomButton> = {
+  title: 'Atoms/CustomButton',
+  component: CustomButton,
+};
+
+export default meta;
+type Story = StoryObj<typeof CustomButton>;
+
+/**
+ * 初期状態では、中サイズのプライマリカラーのボタンが表示されます。
+ * 幅はコンテンツに合わせて自動的に決定されます。
+ */
+export const Default: Story = {
+  args: {
+    children: 'Button',
+  }
+};
+
+/**
+ * アウトラインスタイルのボタンです。
+ */
+export const VariantOutline: Story = {
+  args: {
+    variant: 'outline',
+    children: 'Outline',
+  }
+};
+
+/**
+ * ゴースト
+ */
+export const VariantGhost: Story = {
+  args: {
+    variant: 'ghost',
+    children: 'Ghost',
+  }
+};
+
+/**
+ * 小サイズのボタンです。
+ */
+export const SizeSmall: Story = {
+  args: {
+    size: 'small',
+    children: 'Small',
+  }
+};
+
+/**
+ * 大サイズのボタンです。
+ */
+export const SizeLarge: Story = {
+  args: {
+    size: 'large',
+    children: 'Large',
+  }
+};
+
+/**
+ * ボタンの幅を指定できます。
+ */
+export const Width: Story = {
+  args: {
+    width: 300,
+    children: 'Button',
+  }
+}
+
+/**
+ * widthに `full` を指定すると、ボタンの幅が親要素いっぱいになります。
+ */
+export const WidthFull: Story = {
+  args: {
+    width: 'full',
+    children: 'Full',
+  }
+}

--- a/src/components/Atoms/CustomButton/index.tsx
+++ b/src/components/Atoms/CustomButton/index.tsx
@@ -1,0 +1,94 @@
+
+import { FC, MouseEventHandler, ReactNode } from 'react';
+import Link from 'next/link';
+import styles from './index.module.css'
+import clsx from 'clsx';
+
+interface Props {
+  /**
+   * ボタンの種類
+   */
+  variant?: 'solid' | 'outline' | 'ghost';
+
+  /**
+   * ボタンのサイズ
+   */
+  size?: 'small' | 'medium' | 'large';
+
+  /**
+   * ボタンの幅
+   */
+  width?: 'full' | string | number;
+
+  /**
+   * リンク先
+   */
+  href?: string;
+
+  /**
+   * ターゲット
+   */
+  target?: '_blank' | '_self' | '_parent' | '_top';
+
+  /**
+   * クラス名
+   */
+  className?: string;
+
+  /**
+   * クリック時のイベント
+   */
+  onClick?: () => void;
+
+  /**
+   * 子要素
+   */
+  children: ReactNode;
+}
+
+export const CustomButton: FC<Props> = ({
+  variant = 'solid',
+  size = "md",
+  width,
+  href,
+  target="_self",
+  className,
+  onClick,
+  children
+}) => {
+  const containerClasses = clsx(
+    styles.button,
+    styles[variant],
+    styles[size],
+    className
+  )
+
+  const containerStyles = width === 'full'
+  ? { width: '100%' }
+  : typeof width === 'string'
+  ? { width }
+  : typeof width === 'number'
+  ? { width: `${width}px` }
+  : {};
+
+  return href ? (
+    <Link
+      href={href}
+      target={target}
+      className={containerClasses}
+      style={containerStyles}
+      onClick={onClick}
+    >
+      {children}
+    </Link>
+  ) : (
+    <button
+      type="button"
+      className={containerClasses}
+      style={containerStyles}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/Pages/NewsDetail/index.module.css
+++ b/src/components/Pages/NewsDetail/index.module.css
@@ -79,6 +79,14 @@
   transform: translate(-50%, -50%);
 }
 
+.prevButton {
+  margin-right: auto;
+}
+
+.nextButton {
+  margin-left: auto;
+}
+
 @media screen and (max-width: 768px) {
   .container {
     gap: 50px;

--- a/src/components/Pages/NewsDetail/index.module.css
+++ b/src/components/Pages/NewsDetail/index.module.css
@@ -1,6 +1,8 @@
 .container {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 80px;
+  align-items: center;
 }
 
 .section {
@@ -46,6 +48,35 @@
 .body img {
   width: 100%;
   height: auto;
+}
+
+.control {
+  width: 100%;
+  margin: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.controlInner {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  width: 100%;
+  position: relative;
+}
+
+.controlInner::before {
+  display: block;
+  content: '';
+  width: 2px;
+  height: 50%;
+  background: var(--color-border);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 @media screen and (max-width: 768px) {

--- a/src/components/Pages/NewsDetail/index.tsx
+++ b/src/components/Pages/NewsDetail/index.tsx
@@ -73,13 +73,13 @@ export const NewsDetail: FC<Props> = ({
       <div className={styles.control}>
         <div className={styles.controlInner}>
           { prevId && (
-            <CustomButton href={`/news/details/${prevId}`} variant="ghost" width="50%">
+            <CustomButton href={`/news/details/${prevId}`} variant="ghost" width="50%" className={styles.prevButton}>
               <span className="material-icons">chevron_left</span>
               前の記事
             </CustomButton>
           ) }
           { nextId && (
-            <CustomButton href={`/news/details/${nextId}`} variant="ghost" width="50%">
+            <CustomButton href={`/news/details/${nextId}`} variant="ghost" width="50%" className={styles.nextButton}>
               次の記事
               <span className="material-icons">chevron_right</span>
             </CustomButton>

--- a/src/components/Pages/NewsDetail/index.tsx
+++ b/src/components/Pages/NewsDetail/index.tsx
@@ -2,6 +2,7 @@ import { FC, ReactNode } from 'react';
 import Image from 'next/image';
 import styles from './index.module.css';
 import { Container } from "@/components/Atoms/Container";
+import { CustomButton } from "@/components/Atoms/CustomButton";
 
 interface Props {
   /**
@@ -57,6 +58,19 @@ export const NewsDetail: FC<Props> = ({
         )}
         <div className={styles.body}>{children}</div>
       </section>
+      <div className={styles.control}>
+        <div className={styles.controlInner}>
+          <CustomButton href="/news/1" variant="ghost" width="full">
+            <span className="material-icons">chevron_left</span>
+            前の記事
+          </CustomButton>
+          <CustomButton href="/news/1" variant="ghost" width="full">
+            次の記事
+            <span className="material-icons">chevron_right</span>
+          </CustomButton>
+        </div>
+        <CustomButton href="/news/1" variant="outline" width={240}>ニュース一覧に戻る</CustomButton>
+      </div>
     </Container>
   )
 }

--- a/src/components/Pages/NewsDetail/index.tsx
+++ b/src/components/Pages/NewsDetail/index.tsx
@@ -28,13 +28,25 @@ interface Props {
    * 本文
    */
   children: ReactNode;
+
+  /**
+   * 前の記事のID
+   */
+  prevId?: string | null;
+
+  /**
+   * 次の記事のID
+   */
+  nextId?: string | null;
 }
 
 export const NewsDetail: FC<Props> = ({
   title,
   data,
   eyecatch = {},
-  children
+  children,
+  prevId,
+  nextId
 }) => {
   return (
     <Container
@@ -60,14 +72,18 @@ export const NewsDetail: FC<Props> = ({
       </section>
       <div className={styles.control}>
         <div className={styles.controlInner}>
-          <CustomButton href="/news/1" variant="ghost" width="full">
-            <span className="material-icons">chevron_left</span>
-            前の記事
-          </CustomButton>
-          <CustomButton href="/news/1" variant="ghost" width="full">
-            次の記事
-            <span className="material-icons">chevron_right</span>
-          </CustomButton>
+          { prevId && (
+            <CustomButton href={`/news/details/${prevId}`} variant="ghost" width="50%">
+              <span className="material-icons">chevron_left</span>
+              前の記事
+            </CustomButton>
+          ) }
+          { nextId && (
+            <CustomButton href={`/news/details/${nextId}`} variant="ghost" width="50%">
+              次の記事
+              <span className="material-icons">chevron_right</span>
+            </CustomButton>
+          ) }
         </div>
         <CustomButton href="/news/1" variant="outline" width={240}>ニュース一覧に戻る</CustomButton>
       </div>


### PR DESCRIPTION
## 概要
- CustomButtonコンポーネント追加
- ニュース一覧に戻るボタンを設置
- 前・次の記事へのボタンを設置

## 参考
https://help.microcms.io/ja/knowledge/get-previous-or-next

## プレビュー
https://next-beginner-ts-git-feature-news-detailindex-nittashiori.vercel.app/news/details/sd8ix079c