### PR TITLE
iOS Safari、ハンバーガーメニューのスタイル崩れを対応

### DIFF
--- a/src/components/Organisms/Header/index.module.css
+++ b/src/components/Organisms/Header/index.module.css
@@ -38,13 +38,24 @@
 
 .button {
   height: 100%;
-  aspect-ratio: 1;
-  padding: 21px 16px;
   background: var(--color-primary);
   position: absolute;
   top: 0;
   right: 0;
   z-index: 10;
+}
+
+.buttonWrap {
+  display: flex;
+  width: auto;
+  height: 100%;
+  padding: 21px 16px;
+}
+
+.buttonWrap::before {
+  display: block;
+  content: "";
+  padding-top: 100%;
 }
 
 .buttonInner {

--- a/src/components/Organisms/Header/index.tsx
+++ b/src/components/Organisms/Header/index.tsx
@@ -95,10 +95,12 @@ export const Header = () => {
         className={buttonClass}
         onClick={handleClick}
       >
-        <span className={styles.buttonInner}>
-          <span></span>
-          <span></span>
-          <span></span>
+        <span className={styles.buttonWrap}>
+          <span className={styles.buttonInner}>
+            <span></span>
+            <span></span>
+            <span></span>
+          </span>
         </span>
       </button>
     </header>


### PR DESCRIPTION
## 概要
iOS Safari（16.5.1）でハンバーガーメニューのスタイルが崩れてたため修正。
aspect-ratioが効いてないのが原因だった。

![IMG_BFCF034E2363-1](https://github.com/nittashiori/next-beginner-ts/assets/30612104/da79df31-f8eb-4552-8dc0-39cac09cf011)
