### PR TITLE
ハンバーガーメニューのバグを簡略化

### DIFF
--- a/src/components/Organisms/Header/index.module.css
+++ b/src/components/Organisms/Header/index.module.css
@@ -14,12 +14,11 @@
 
 .nav ul {
   display: flex;
-  gap: 16px;
 }
 
 .nav a {
   display: block;
-  padding: 4px 8px;
+  padding: 12px 8px;
   border-radius: 4px;
   transition: var(--transition-base);
 }

--- a/src/components/Organisms/Header/index.module.css
+++ b/src/components/Organisms/Header/index.module.css
@@ -39,7 +39,6 @@
 .button {
   height: 100%;
   aspect-ratio: 1;
-  padding: 21px 16px;
   background: var(--color-primary);
   position: absolute;
   top: 0;
@@ -53,6 +52,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  margin: auto;
 }
 
 .buttonInner span {

--- a/src/components/Organisms/Header/index.module.css
+++ b/src/components/Organisms/Header/index.module.css
@@ -38,24 +38,13 @@
 
 .button {
   height: 100%;
+  aspect-ratio: 1;
+  padding: 21px 16px;
   background: var(--color-primary);
   position: absolute;
   top: 0;
   right: 0;
   z-index: 10;
-}
-
-.buttonWrap {
-  display: flex;
-  width: auto;
-  height: 100%;
-  padding: 21px 16px;
-}
-
-.buttonWrap::before {
-  display: block;
-  content: "";
-  padding-top: 100%;
 }
 
 .buttonInner {

--- a/src/components/Organisms/Header/index.tsx
+++ b/src/components/Organisms/Header/index.tsx
@@ -95,12 +95,10 @@ export const Header = () => {
         className={buttonClass}
         onClick={handleClick}
       >
-        <span className={styles.buttonWrap}>
-          <span className={styles.buttonInner}>
-            <span></span>
-            <span></span>
-            <span></span>
-          </span>
+        <span className={styles.buttonInner}>
+          <span></span>
+          <span></span>
+          <span></span>
         </span>
       </button>
     </header>


### PR DESCRIPTION
## 概要
iOS Safariのハンバーガーメニューのスタイル崩れは
aspect-ratioが効いてないのではなくて、paddingを追加してたのが原因だった。
htmlを余分に増やしたため修正内容を簡略化した。